### PR TITLE
Fix sidechain statistics

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,8 @@ Develop branch
 
 - Imported GSoC 2014 changes, including updating to Django 1.6 (#17649)
 
+- Fixed sidechain statistics which broke as a result of the upgrade (#18159)    
+
 Version 1.0.2: released 2013 Oct 07
 
 - Fixed corrupt selection file generation (#15141)
@@ -30,4 +32,4 @@ Version 1.0.0: released 2013 Aug 15
 
 - Sidechain lengths and angles are now reset when amino acids are deselected (#13623)
 
-  - Standard deviations are now calculated correctly on the search statistics page (#12459)
+- Standard deviations are now calculated correctly on the search statistics page (#12459)

--- a/pgd_search/statistics/views.py
+++ b/pgd_search/statistics/views.py
@@ -106,7 +106,7 @@ def search_statistics_aa_data(request, aa):
     """
     returns ajax'ified statistics data for a single aa in the current search
     """
-    search = request.session['search']
+    search = pickle.loads(request.session['search'])
     try:        
         index = int(request.GET['i']) if request.GET.has_key('i') else 0
         stats = calculate_aa_statistics(search.querySet(), aa, index)

--- a/pgd_search/tests.py
+++ b/pgd_search/tests.py
@@ -746,7 +746,7 @@ class SidechainStatistics(LiveServerTestCase):
         # Wait for qtip to disappear
         qtip_xpath = "//div[contains(., 'Calculating Statistics')]"
         try:
-            qtip_element = WebDriverWait(self.driver, 10).until(
+            qtip_element = WebDriverWait(self.driver, 60).until(
                 EC.invisibility_of_element_located((By.XPATH, qtip_xpath))
             )
         except:
@@ -757,11 +757,7 @@ class SidechainStatistics(LiveServerTestCase):
         cbcg_xpath = "//div[@id='aa_r']/table/tbody/tr[@class='avg']/td[@class='CB_CG']"
 
         # Before selecting the sidechain, the cbcg value should not be visible.
-        try:
-            cbcg_element = self.driver.find_element_by_xpath(cbcg_xpath)
-        except:
-            self.driver.save_screenshot("no-cbcg-element.png")
-            self.fail("no cbcg element found")
+        cbcg_element = self.driver.find_element_by_xpath(cbcg_xpath)
         self.assertFalse(cbcg_element.is_displayed())
 
         # Visit 'Arg' sidechain

--- a/pgd_search/tests.py
+++ b/pgd_search/tests.py
@@ -1,6 +1,10 @@
 import unittest
 import datetime
 from selenium import webdriver
+from selenium.common.exceptions import NoSuchElementException
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
 from pgd_search.models import *
 from pgd_core.models import *
 #from pgd_splicer.SegmentBuilder import SegmentBuilderTask
@@ -710,7 +714,7 @@ class PersistingSearchOptions(LiveServerTestCase):
 
 
 class SidechainStatistics(LiveServerTestCase):
-    # JMT: fixtures?
+    fixtures = ['pgd_core']
 
     @classmethod
     def setUpClass(cls):
@@ -727,22 +731,44 @@ class SidechainStatistics(LiveServerTestCase):
         self.driver.get(self.live_server_url + "/search")
 
         # Run default search
-        self.driver.find_element_by_class_name('submit').click()
+        self.driver.find_element_by_css_selector('input.submit').click()
 
         # Visit statistics link
-        self.driver.find_element_by_link_text('Statistics').click()
+        try:
+            stats_link = WebDriverWait(self.driver, 10).until(
+                EC.presence_of_element_located((By.LINK_TEXT, 'Statistics'))
+            )
+            self.driver.find_element_by_link_text('Statistics').click()
+        except:
+            self.driver.save_screenshot("no-statistics.png")
+            self.fail("no stats link")
 
-        # The first div is for Arg.
-        div_xpath = "//div[@id='aa_r']"
-        h2_xpath = div_xpath+"/h2"
-        cbcg_xpath = div_xpath+"/table/tbody/tr[@class='avg']/td[@class='CB_CG']"
+        # Wait for qtip to disappear
+        qtip_xpath = "//div[contains(., 'Calculating Statistics')]"
+        try:
+            qtip_element = WebDriverWait(self.driver, 10).until(
+                EC.invisibility_of_element_located((By.XPATH, qtip_xpath))
+            )
+        except:
+            self.driver.save_screenshot("no-qtip.png")
+            self.fail("qtip does not disappear")
 
-        # Before selecting the sidechain, the cbcg value should be '--'.
-        cbcg_val = self.driver.find_element_by_xpath(cbcg_xpath)
-        self.assertFalse(cbcg_val.is_displayed())
+        # Arg div table value should not be visible.
+        cbcg_xpath = "//div[@id='aa_r']/table/tbody/tr[@class='avg']/td[@class='CB_CG']"
+
+        # Before selecting the sidechain, the cbcg value should not be visible.
+        try:
+            cbcg_element = self.driver.find_element_by_xpath(cbcg_xpath)
+        except:
+            self.driver.save_screenshot("no-cbcg-element.png")
+            self.fail("no cbcg element found")
+        self.assertFalse(cbcg_element.is_displayed())
 
         # Visit 'Arg' sidechain
+        h2_xpath = "//div[@id='aa_r']/h2"
         self.driver.find_element_by_xpath(h2_xpath).click()
 
-        # After, it should be something else!
-        self.assertTrue(cbcg_val.is_displayed())
+        # After, it should be visible and not equal to '--'.
+        # cbcg_element = self.driver.find_element_by_css_selector("td.CB_CG")
+        self.assertTrue(cbcg_element.is_displayed())
+        self.assertNotEqual("--", cbcg_element.text)

--- a/pgd_search/tests.py
+++ b/pgd_search/tests.py
@@ -707,3 +707,42 @@ class PersistingSearchOptions(LiveServerTestCase):
         # What I did see:
         # The CbCg box contains "1".
         pass
+
+
+class SidechainStatistics(LiveServerTestCase):
+    # JMT: fixtures?
+
+    @classmethod
+    def setUpClass(cls):
+        cls.driver = webdriver.PhantomJS()
+        super(SidechainStatistics, cls).setUpClass()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.driver.quit()
+        super(SidechainStatistics, cls).tearDownClass()
+
+    def test_sidechain_statistics_present(self):
+        # Load search page
+        self.driver.get(self.live_server_url + "/search")
+
+        # Run default search
+        self.driver.find_element_by_class_name('submit').click()
+
+        # Visit statistics link
+        self.driver.find_element_by_link_text('Statistics').click()
+
+        # The first div is for Arg.
+        div_xpath = "//div[@id='aa_r']"
+        h2_xpath = div_xpath+"/h2"
+        cbcg_xpath = div_xpath+"/table/tbody/tr[@class='avg']/td[@class='CB_CG']"
+
+        # Before selecting the sidechain, the cbcg value should be '--'.
+        cbcg_val = self.driver.find_element_by_xpath(cbcg_xpath)
+        self.assertFalse(cbcg_val.is_displayed())
+
+        # Visit 'Arg' sidechain
+        self.driver.find_element_by_xpath(h2_xpath).click()
+
+        # After, it should be something else!
+        self.assertTrue(cbcg_val.is_displayed())


### PR DESCRIPTION
The sidechain statistics broke as a result of the upgrade to Django 1.6.  They have been fixed, and tests have been written to confirm their fixed state.
