### PR TITLE
Restored init file, hopefully prevent future losses

### DIFF
--- a/dev-setup.sh
+++ b/dev-setup.sh
@@ -3,6 +3,7 @@
 # clean up current situation
 docker-compose stop
 docker-compose rm --force
+find . \( -name "*.pyc" -o -name "*.pyo" \) -print0 | xargs -0 rm
 
 # rebuild containers
 docker-compose build


### PR DESCRIPTION
The pgd/**init**.py file was removed because it was thought no longer
necessary, since the software continued to work afterwards.

Of course, it only worked because pgd/**init**.pyc was still around.

So, dev-setup.sh will now sweep .pyc files, and pgd/**init**.py has
now been returned.
