### PR TITLE
Tests are now silent

### DIFF
--- a/pgd_search/plot/views.py
+++ b/pgd_search/plot/views.py
@@ -130,7 +130,7 @@ def renderToPNG(request):
         width = 560
         height = 480
 
-    response = HttpResponse(mimetype="image/png")
+    response = HttpResponse(content_type="image/png")
     response['Content-Disposition'] = 'attachment; filename="plot.png"'
     svg.render_png(response, width, height+30)
 
@@ -248,7 +248,7 @@ def plotDump(request):
                 pickle.loads(request.session['search']).querySet()
             )
 
-            response = HttpResponse(mimetype="text/tab-separated-values")
+            response = HttpResponse(content_type="text/tab-separated-values")
             response['Content-Disposition'] = 'attachment; filename="plot.tsv"'
 
             cdp.Plot()
@@ -257,6 +257,3 @@ def plotDump(request):
             return response
 
     return HttpResponse('Error')
-
-
-

--- a/pgd_search/statistics/views.py
+++ b/pgd_search/statistics/views.py
@@ -190,7 +190,7 @@ def calculate_statistics(queryset, iIndex=0):
     #print '  -stats: %s (%s)' % (now-start, now-last)
     last = now
     end = time.time()
-    print 'Search Statistics Data in seconds: ', end-start
+    # print 'Search Statistics Data in seconds: ', end-start
 
     return stats
 

--- a/pgd_splicer/management/commands/fetch.py
+++ b/pgd_splicer/management/commands/fetch.py
@@ -6,7 +6,6 @@ import urllib
 import re
 import gzip
 from cStringIO import StringIO
-import sys
 import os
 import time
 from ftplib import FTP, error_perm
@@ -63,8 +62,8 @@ class Command(BaseCommand):
 
     def process_chunk(self, data):
         """ Callback for FTP download progress bar. """
-        sys.stdout.write('.')
-        sys.stdout.flush()
+        self.stdout.write('x')
+        self.stdout.flush()
         self.infile.write(data)
 
     def fetch_pdb(self, ftp, code):
@@ -97,7 +96,7 @@ class Command(BaseCommand):
         self.stdout.write(self.prefix(code))
         ftp.retrbinary('RETR %s' % filename, self.process_chunk)
         self.infile.close()
-        sys.stdout.write('\n')
+        self.stdout.write('\n')
         if date:
             return 'changed'
         else:
@@ -111,7 +110,7 @@ class Command(BaseCommand):
         self.r_factor = options['r_factor']
         self.verbose = options['verbose']
 
-        print 'Reading selection page from website...'
+        self.stdout.write('Reading selection page from website...\n')
         selection_page = urllib.urlopen(self.dunbrack_url).read()
         # FIXME: Grab the links based on the filenames!
         # <A href="link"> filename </A><br>
@@ -124,7 +123,7 @@ class Command(BaseCommand):
         regex_str = '(\w{4})(\w)\s+(\d+)\s+(\w+)\s+([\d\.]+)\s+([\d\.]+)\s+([\d\.]+)'
         regex_pattern = re.compile(regex_str)
 
-        print 'Retrieving cull files...'
+        self.stdout.write('Retrieving cull files...\n')
         for filename, threshold in files:
             # get file
             webfile = urllib.urlopen('/'.join([self.dunbrack_url, filename]))
@@ -174,7 +173,7 @@ class Command(BaseCommand):
 
         # output selections
         if options['selection']:
-            print 'Writing selections to %s...' % options['selection']
+            self.stdout.write('Writing selections to %s...\n' % options['selection'])
             with open(options['selection'], 'w') as out:
                 out.write('VERSION: %s\n' % version)
                 for k, v in self.proteins.items():
@@ -202,7 +201,7 @@ class Command(BaseCommand):
             os.mkdir(self.localdir)
 
         # make FTP connection
-        print 'Connecting via FTP to %s...' % self.ftphost
+        self.stdout.write('Connecting via FTP to %s...\n' % self.ftphost)
         ftp = FTP(self.ftphost)
         ftp.login()
         ftp.cwd(self.remotedir)
@@ -219,11 +218,11 @@ class Command(BaseCommand):
             try:
                 self.files[result].append(code)
             except KeyError:
-                print "Invalid result %s from code %s" % (result, code)
+                self.stderr.write("Invalid result %s from code %s\n" % (result, code))
 
         # output report
         if options['report']:
-            print 'Writing report to %s...' % options['report']
+            self.stdout.write('Writing report to %s...\n' % options['report'])
             with open(options['report'], 'w') as out:
                 if self.extras is []:
                     out.write('No extraneous proteins were found.\n')

--- a/pgd_splicer/tests.py
+++ b/pgd_splicer/tests.py
@@ -217,6 +217,10 @@ class ManagementCommands(TestCase):
 
     fixtures = ['pgd_core']
 
+    def setUp(self):
+        self.out = StringIO()
+        self.err = StringIO()
+
     def test_fetch_old(self):
         # How far into the past do we set the test files?
         howfar = 86400 * 365 * 10
@@ -244,7 +248,7 @@ class ManagementCommands(TestCase):
                 os.utime(proteins[key], (-1, olddates[key] - howfar))
 
             # Run the management command.
-            management.call_command('fetch')
+            management.call_command('fetch', stdout=self.out)
 
             # Record the file dates now.
             for key in proteins:
@@ -273,7 +277,7 @@ class ManagementCommands(TestCase):
                     os.remove(proteins[key])
 
             # Run the management command.
-            management.call_command('fetch')
+            management.call_command('fetch', stdout=self.out)
 
             # Only the 3CGX file should now exist.
             self.assertTrue(os.path.exists(proteins['3cgx']))
@@ -304,7 +308,7 @@ class ManagementCommands(TestCase):
             # Add 3CGX.
             good_dict['3CGX'] = ['A', '25', '1.900', '0.17', '0.21']
             test_selection = MonkeyPatch.localfile('test_selection.txt')
-            management.call_command('fetch', selection=test_selection)
+            management.call_command('fetch', stdout=self.out, selection=test_selection)
             test_dict = self.file_to_dict(test_selection)
             self.assertEqual(good_dict, test_dict)
             if os.path.exists(test_selection):


### PR DESCRIPTION
Warnings about deprecation of mimetype in pgd_search/plot/views.py
were addressed.  Ancient statistics data reports were silenced.
References to print and sys.stdout were changed to self.stdout as per
best practices.  management.call_command() now traps stdout for
commands where it was not previously trapped.
