### PR TITLE
Using old save behavior and chain PKs are unique

### DIFF
--- a/pgd_core/models.py
+++ b/pgd_core/models.py
@@ -17,6 +17,10 @@ class Protein(models.Model):
     # updates allowing up-to-date proteins to be skipped.
     pdb_date    = models.DateTimeField()
 
+    # JMT: upgrade to Django 1.6 caused deadlocks on insert
+    class Meta:
+        select_on_save = True
+
     def __unicode__(self):
         return self.code
 
@@ -29,9 +33,13 @@ class Protein(models.Model):
 # in the residue table.  Once splicer is updated and importing directly to the database the PK
 # will be changed to an integer.
 class Chain (models.Model):
-        id      = models.CharField(max_length=5, primary_key=True)
-        protein = models.ForeignKey(Protein, related_name='chains')
-        code    = models.CharField(max_length=1)
+    id      = models.CharField(max_length=5, primary_key=True, unique=True)
+    protein = models.ForeignKey(Protein, related_name='chains')
+    code    = models.CharField(max_length=1)
+
+    # JMT: upgrade to Django 1.6 caused deadlocks on insert
+    class Meta:
+        select_on_save = True
 
 
 class Sidechain_ARG(models.Model):

--- a/pgd_splicer/ProcessPDBTask.py
+++ b/pgd_splicer/ProcessPDBTask.py
@@ -335,7 +335,7 @@ def pdb_file_is_newer(data):
         pdb_date = timezone.make_aware(datetime.fromtimestamp(os.path.getmtime(path)), timezone.get_default_timezone())
 
     else:
-        print 'ERROR - File not found'
+        print 'ERROR - File not found: %s' % path
         return False
     try:
         protein = ProteinModel.objects.get(code=code)
@@ -387,9 +387,7 @@ def parseWithBioPython(path, props, chains_filter=None):
     @return a dict containing the properties that were processed
     """
 
-    pdb = './pdb'
-
-    full_path = os.path.abspath(os.path.join(pdb, path))
+    full_path = os.path.abspath(os.path.join(settings.PDB_LOCAL_DIR, path))
 
     chains = props['chains']
 

--- a/pgd_splicer/tests.py
+++ b/pgd_splicer/tests.py
@@ -15,7 +15,8 @@ import time
 
 # 1.  Drop the dev database, re-create it and syncdb.
 # 2.  Populate the dev database.
-#     $ ./pgd_splicer/ProcessPDBTask.py --pipein < \
+#     $ PDB_LOCAL_DIR=./pgd_splicer/testfiles \
+#       ./pgd_splicer/ProcessPDBTask.py --pipein < \
 #       ./pgd_splicer/testfiles/fixture_selection.txt
 # 3.  Write the fixture from the database.
 #     $ python manage.py dumpdata pgd_core --indent 2 --format json > \


### PR DESCRIPTION
The pre-1.6 save behavior is still available by adding select_on_save to
the Meta class for the relevant models.  Also, the Chain id was a
primary key but not unique, which contributed to the deadlocks.

Fixing both of these works on up to 100 proteins.  I want to test it
against a full-sized run before merging it into the codebase.
