### PR TITLE
Fixed docs for fixture generation, plus bugfix.

### DIFF
--- a/pgd_splicer/ProcessPDBTask.py
+++ b/pgd_splicer/ProcessPDBTask.py
@@ -335,7 +335,7 @@ def pdb_file_is_newer(data):
         pdb_date = timezone.make_aware(datetime.fromtimestamp(os.path.getmtime(path)), timezone.get_default_timezone())
 
     else:
-        print 'ERROR - File not found'
+        print 'ERROR - File not found: %s' % path
         return False
     try:
         protein = ProteinModel.objects.get(code=code)
@@ -387,9 +387,7 @@ def parseWithBioPython(path, props, chains_filter=None):
     @return a dict containing the properties that were processed
     """
 
-    pdb = './pdb'
-
-    full_path = os.path.abspath(os.path.join(pdb, path))
+    full_path = os.path.abspath(os.path.join(settings.PDB_LOCAL_DIR, path))
 
     chains = props['chains']
 

--- a/pgd_splicer/tests.py
+++ b/pgd_splicer/tests.py
@@ -15,7 +15,8 @@ import time
 
 # 1.  Drop the dev database, re-create it and syncdb.
 # 2.  Populate the dev database.
-#     $ ./pgd_splicer/ProcessPDBTask.py --pipein < \
+#     $ PDB_LOCAL_DIR=./pgd_splicer/testfiles \
+#       ./pgd_splicer/ProcessPDBTask.py --pipein < \
 #       ./pgd_splicer/testfiles/fixture_selection.txt
 # 3.  Write the fixture from the database.
 #     $ python manage.py dumpdata pgd_core --indent 2 --format json > \


### PR DESCRIPTION
I accidentally left one explicit reference to './pdb'.  Replaced that
reference with the correct value, and now PDB_LOCAL_DIR actually works
with ProcessPDBTask.  The tests documentation for regenerating the
fixtures has now been updated.

Like every other import, sometimes this will deadlock.  There is a
proposed fix for this issue, so I am not documenting the deadlock
behavior.
