### PR TITLE
Improved integration tests.

### DIFF
--- a/dev-setup.sh
+++ b/dev-setup.sh
@@ -3,7 +3,7 @@
 # clean up current situation
 docker-compose stop
 docker-compose rm --force
-find . \( -name "*.pyc" -o -name "*.pyo" \) -print0 | xargs -0 rm
+find . \( -name "*.pyc" -o -name "*.pyo" \) -print0 | xargs -0 rm -rf
 
 # rebuild containers
 docker-compose build

--- a/integration-test.sh
+++ b/integration-test.sh
@@ -1,45 +1,71 @@
 #!/bin/bash
-EMPTY=0
-HOWMANY=10
-SHORTFILE=short-selection.txt
 
-proteincount () {
-    return 
-}
+# takes an optional argument: how many proteins to retrieve and import
+
+EMPTY=0
+HOWMANY=${1:-10}
+
+SELFILE=$(mktemp)
+SHORTFILE=$(mktemp)
+
+# check if we are running on docker
+IN_DOCKER=$(grep -q docker /proc/1/cgroup)$?
+if [[ $IN_DOCKER -eq 1 ]]; then
+    DOCKER='docker-compose run web'
+else
+    DOCKER=
+fi
 
 # delete proteins from database
-docker-compose run web bash -c 'echo "from pgd_core.models import Protein; Protein.objects.all().delete(); exit()" | python manage.py shell' >/dev/null
+$DOCKER bash -c 'echo "from pgd_core.models import Protein; Protein.objects.all().delete(); exit()" | python manage.py shell' >/dev/null
 
 # the database should contain ${EMPTY} proteins
-BEFORE=`docker-compose run web bash -c 'echo "from pgd_core.models import Protein; print Protein.objects.count(); exit()" | python manage.py shell' | tail -1 | awk '{ print $2 }' | tr -d '[[:space:]]'`
+TESTEMPTY=0
+BEFORE=`$DOCKER bash -c 'echo "from pgd_core.models import Protein; print Protein.objects.count(); exit()" | python manage.py shell' | tail -1 | awk '{ print $2 }' | tr -d '[[:space:]]'`
 if [[ $BEFORE -ne $EMPTY ]]; then
     echo "FAIL: $((BEFORE)) proteins found, should be $((EMPTY))"
 else
     echo "PASS: $((EMPTY)) proteins found"
+    TESTEMPTY=1
 fi
 
 # generate selection file
-docker-compose run web python ./pgd_splicer/dunbrack_selector.py --pipeout > selection.txt
-sed ${HOWMANY}q selection.txt > ${SHORTFILE}
+$DOCKER python ./pgd_splicer/dunbrack_selector.py --pipeout > ${SELFILE}
+sed ${HOWMANY}q ${SELFILE} > ${SHORTFILE}
 
 # retrieve files
-docker-compose run web python ./pgd_splicer/ftpupdate.py --pipein < ${SHORTFILE}
+$DOCKER find /opt/pgd/pdb -type f -exec rm {} \;
+$DOCKER python ./pgd_splicer/ftpupdate.py --pipein < ${SHORTFILE}
 
 # this command should list ${HOWMANY} files
-FILES=`docker-compose run web ls -1 /opt/pgd/pdb | wc -l`
+TESTFILES=0
+FILES=`$DOCKER ls -1 /opt/pgd/pdb | wc -l`
 if [[ $FILES -ne $HOWMANY ]]; then
     echo "FAIL: $((FILES)) files found, should be $((HOWMANY))"
 else
     echo "PASS: $((HOWMANY)) files found"
+    TESTFILES=1
 fi
 
 # add proteins to database
-docker-compose run web python ./pgd_splicer/ProcessPDBTask.py --pipein < ${SHORTFILE}
+$DOCKER python ./pgd_splicer/ProcessPDBTask.py --pipein < ${SHORTFILE}
 
 # the database should contain ${HOWMANY} proteins
-AFTER=`docker-compose run web bash -c 'echo "from pgd_core.models import Protein; print Protein.objects.count(); exit()" | python manage.py shell' | tail -1 | awk '{ print $2 }' | tr -d '[[:space:]]'`
+TESTFULL=0
+AFTER=`$DOCKER bash -c 'echo "from pgd_core.models import Protein; print Protein.objects.count(); exit()" | python manage.py shell' | tail -1 | awk '{ print $2 }' | tr -d '[[:space:]]'`
 if [[ $AFTER -ne $HOWMANY ]]; then
     echo "FAIL: $((AFTER)) proteins found, should be $((HOWMANY))"
 else
     echo "PASS: $((HOWMANY)) proteins found"
+    TESTFULL=1
 fi
+
+rm -rf ${SELFILE} ${SHORTFILE}
+
+# final score
+if [[ ${TESTEMPTY} -eq 1 && ${TESTFILES} -eq 1 && ${TESTFULL} -eq 1 ]]; then
+    exit 0
+else
+    exit 1
+fi
+


### PR DESCRIPTION
The "-rf" was left off the cleanup line in dev-setup.sh, and that is now
corrected.

The integration-test.sh file now creates and deletes temporary files for
the selection files.

It also accepts an optional argument for how many proteins to select.

When the script runs in a Docker container, it generates more output
which is very useful for debugging purposes.
