### PR TITLE
Updated Docker Compose configuration to v2.

### DIFF
--- a/dev-setup.sh
+++ b/dev-setup.sh
@@ -2,22 +2,29 @@
 
 # clean up current situation
 docker-compose stop
-docker-compose rm --force
+docker-compose rm -v --force
 find . \( -name "*.pyc" -o -name "*.pyo" \) -print0 | xargs -0 rm -rf
 
 # rebuild containers
 docker-compose build
 
 # start data containers
-docker-compose up -d mysql pdb
+docker-compose up -d mysql
 
 # collectstatic
-docker-compose run web python manage.py collectstatic --noinput
+docker-compose run --rm web python manage.py collectstatic --noinput
 
 # create database
 # due to race conditions, this may require multiple attempts
 retcode=1
-while [ $retcode -ne 0 ]; do
-    docker-compose run web python manage.py syncdb --noinput >/dev/null 2>/dev/null
+count=0
+syncdbmax=10
+while [ $retcode -ne 0 -o $count -eq $syncdbmax ]; do
+    docker-compose run --rm web python manage.py syncdb --noinput >/dev/null 2>/dev/null
+    count=`expr $count + 1`
     retcode=$?
 done
+if [ $count -eq $syncdbmax ]; then
+    echo "syncdb failed:"
+    docker-compose run --rm web python manage.py syncdb --noinput
+fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
         networks:
             - front-tier
             - back-tier
+        entrypoint: ./wait-for-it.sh -q db:5432 --
     mysql:
         image: mysql/mysql-server:5.5
         volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,36 +1,42 @@
-mysql:
- image: mysql:5.5
- environment:
-   MYSQL_ROOT_PASSWORD: pgd_root_password
-   MYSQL_USER: pgd_user
-   MYSQL_PASSWORD: pgd_user_password
-   MYSQL_DATABASE: pgd_db
-
-pdb:
-  image: centos:7
-  volumes:
-    - /opt/pgd/pdb
-  command: /bin/true
-
-media:
-  image: centos:7
-  volumes:
-    - /opt/pgd/media
-  command: /bin/true
-
-static:
-  image: centos:7
-  volumes:
-    - /opt/pgd/static
-  command: /bin/true
-
-web:
-  build: .
-  volumes_from:
-    - pdb
-    - media
-    - static
-  ports:
-    - "8000:8000"
-  links:
-    - mysql
+version: '2'
+services:
+    web:
+        build: .
+        ports:
+            - "8000:8000"
+        volumes:
+            - pdb:/opt/pgd/pdb
+            - media:/opt/pgd/media
+            - static:/opt/pgd/static
+        links:
+            - mysql
+        environment:
+            DATABASE_URL: mysql://pgd_user:pgd_user_password@mysql:3306/pgd_db
+        networks:
+            - front-tier
+            - back-tier
+    mysql:
+        image: mysql/mysql-server:5.5
+        volumes:
+            - dbdata:/var/lib/mysql
+        environment:
+            MYSQL_ROOT_PASSWORD: pgd_root_password
+            MYSQL_USER: pgd_user
+            MYSQL_PASSWORD: pgd_user_password
+            MYSQL_DATABASE: pgd_db
+        networks:
+            - back-tier
+volumes:
+    pdb:
+        driver: local
+    media:
+        driver: local
+    static:
+        driver: local
+    dbdata:
+        driver: local
+networks:
+    front-tier:
+        driver: bridge
+    back-tier:
+        driver: bridge

--- a/pgd/settings.py
+++ b/pgd/settings.py
@@ -15,16 +15,9 @@ MANAGERS = ADMINS
 
 # At this time only MySQL is supported.  When other databases are
 # supported, these settings will be refactored.
-
+import dj_database_url
 DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.mysql',  # 'postgresql_psycopg2'
-        'NAME': config('MYSQL_ENV_MYSQL_DATABASE', default='db'),
-        'USER': config('MYSQL_ENV_MYSQL_USER', default='root'),
-        'PASSWORD': config('MYSQL_ENV_MYSQL_PASSWORD', default='scott'),
-        'HOST': config('MYSQL_PORT_3306_TCP_ADDR', default=''),
-        'PORT': config('MYSQL_PORT_3306_TCP_PORT', default=''),
-    }
+    'default': dj_database_url.config()
 }
 import sys
 if 'test' in sys.argv:

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ pytz
 Sphinx
 python-decouple==2.3
 docker-compose==1.2.0
+dj-database-url

--- a/wait-for-it.sh
+++ b/wait-for-it.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+#   Use this script to test if a given TCP host/port are available
+
+cmdname=$(basename $0)
+
+echoerr() { if [[ $QUIET -ne 1 ]]; then echo "$@" 1>&2; fi }
+
+usage()
+{
+    cat << USAGE >&2
+Usage:
+    $cmdname host:port [-s] [-t timeout] [-- command args]
+    -h HOST | --host=HOST       Host or IP under test
+    -p PORT | --port=PORT       TCP port under test
+                                Alternatively, you specify the host and port as host:port
+    -s | --strict               Only execute subcommand if the test succeeds
+    -q | --quiet                Don't output any status messages
+    -t TIMEOUT | --timeout=TIMEOUT
+                                Timeout in seconds, zero for no timeout
+    -- COMMAND ARGS             Execute command with args after the test finishes
+USAGE
+    exit 1
+}
+
+wait_for()
+{
+    if [[ $TIMEOUT -gt 0 ]]; then
+        echoerr "$cmdname: waiting $TIMEOUT seconds for $HOST:$PORT"
+    else
+        echoerr "$cmdname: waiting for $HOST:$PORT without a timeout"
+    fi
+    start_ts=$(date +%s)
+    while :
+    do
+        (echo > /dev/tcp/$HOST/$PORT) >/dev/null 2>&1
+        result=$?
+        if [[ $result -eq 0 ]]; then
+            end_ts=$(date +%s)
+            echoerr "$cmdname: $HOST:$PORT is available after $((end_ts - start_ts)) seconds"
+            break
+        fi
+        sleep 1
+    done
+    return $result
+}
+
+wait_for_wrapper()
+{
+    # In order to support SIGINT during timeout: http://unix.stackexchange.com/a/57692
+    if [[ $QUIET -eq 1 ]]; then
+        timeout $TIMEOUT $0 --quiet --child --host=$HOST --port=$PORT --timeout=$TIMEOUT &
+    else
+        timeout $TIMEOUT $0 --child --host=$HOST --port=$PORT --timeout=$TIMEOUT &
+    fi
+    PID=$!
+    trap "kill -INT -$PID" INT
+    wait $PID
+    RESULT=$?
+    if [[ $RESULT -ne 0 ]]; then
+        echoerr "$cmdname: timeout occurred after waiting $TIMEOUT seconds for $HOST:$PORT"
+    fi
+    return $RESULT
+}
+
+# process arguments
+while [[ $# -gt 0 ]]
+do
+    case "$1" in
+        *:* )
+        hostport=(${1//:/ })
+        HOST=${hostport[0]}
+        PORT=${hostport[1]}
+        shift 1
+        ;;
+        --child)
+        CHILD=1
+        shift 1
+        ;;
+        -q | --quiet)
+        QUIET=1
+        shift 1
+        ;;
+        -s | --strict)
+        STRICT=1
+        shift 1
+        ;;
+        -h)
+        HOST="$2"
+        if [[ $HOST == "" ]]; then break; fi
+        shift 2
+        ;;
+        --host=*)
+        HOST="${1#*=}"
+        shift 1
+        ;;
+        -p)
+        PORT="$2"
+        if [[ $PORT == "" ]]; then break; fi
+        shift 2
+        ;;
+        --port=*)
+        PORT="${1#*=}"
+        shift 1
+        ;;
+        -t)
+        TIMEOUT="$2"
+        if [[ $TIMEOUT == "" ]]; then break; fi
+        shift 2
+        ;;
+        --timeout=*)
+        TIMEOUT="${1#*=}"
+        shift 1
+        ;;
+        --)
+        shift
+        CLI="$@"
+        break
+        ;;
+        --help)
+        usage
+        ;;
+        *)
+        echoerr "Unknown argument: $1"
+        usage
+        ;;
+    esac
+done
+
+if [[ "$HOST" == "" || "$PORT" == "" ]]; then
+    echoerr "Error: you need to provide a host and port to test."
+    usage
+fi
+
+TIMEOUT=${TIMEOUT:-15}
+STRICT=${STRICT:-0}
+CHILD=${CHILD:-0}
+QUIET=${QUIET:-0}
+
+if [[ $CHILD -gt 0 ]]; then
+    wait_for
+    RESULT=$?
+    exit $RESULT
+else
+    if [[ $TIMEOUT -gt 0 ]]; then
+        wait_for_wrapper
+        RESULT=$?
+    else
+        wait_for
+        RESULT=$?
+    fi
+fi
+
+if [[ $CLI != "" ]]; then
+    if [[ $RESULT -ne 0 && $STRICT -eq 1 ]]; then
+        echoerr "$cmdname: strict mode, refusing to execute subprocess"
+        exit $RESULT
+    fi
+    exec $CLI
+else
+    exit $RESULT
+fi


### PR DESCRIPTION
Docker Compose released a new configuration version recently.  Certain features we were using in version 1 are being deprecated, such as environment variables.  Additionally, data-only containers are no longer best-practice now that data volumes are released.

The configuration file now uses data volumes and networks as encouraged by the new configuration version.

The change in environment variable support necessitated a change in the database configuration in our settings.  This change will break the settings.ini file on production and staging, but the fix is straightforward.

Some other minor but useful and related changes to dev-setup.sh also occurred.
